### PR TITLE
Godot 4.3 Compatibility Fix

### DIFF
--- a/addons/kaykit_dungeon_remastered/Assets/gltf/barrel_large_decorated.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/barrel_large_decorated.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:barrel_large_decorated": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/barrel_small_stack.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/barrel_small_stack.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:barrel_small_stack": {
 "decomposition/precision": 9,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_A_brown.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_A_brown.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:bottle_A_brown": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_A_green.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_A_green.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:bottle_A_green": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_A_labeled_brown.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_A_labeled_brown.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:bottle_A_labeled_brown": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_A_labeled_green.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_A_labeled_green.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:bottle_A_labeled_green": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_B_brown.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_B_brown.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:bottle_B_brown": {
 "decomposition/precision": 8,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_B_green.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_B_green.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:bottle_B_green": {
 "decomposition/precision": 8,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_C_brown.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_C_brown.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:bottle_C_brown": {
 "decomposition/precision": 8,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_C_green.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/bottle_C_green.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:bottle_C_green": {
 "decomposition/precision": 8,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/coin_stack_large.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/coin_stack_large.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:coin_stack_large": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/coin_stack_medium.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/coin_stack_medium.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:coin_stack_medium": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/coin_stack_small.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/coin_stack_small.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:coin_stack_small": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/keg.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/keg.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:keg": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/key.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/key.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:key": {
 "decomposition/precision": 6,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/keyring.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/keyring.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:keyring": {
 "decomposition/precision": 10,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/keyring_hanging.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/keyring_hanging.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:keyring_hanging": {
 "decomposition/precision": 10,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/plate_food_A.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/plate_food_A.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:plate_food_A": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/plate_food_B.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/plate_food_B.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:plate_food_B": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/plate_stack.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/plate_stack.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:plate_stack": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/rubble_half.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/rubble_half.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:rubble_half": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/rubble_large.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/rubble_large.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:rubble_large": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/table_long_broken.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/table_long_broken.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:table_long_broken": {
 "decomposition/precision": 9,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/table_medium_broken.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/table_medium_broken.gltf.import
@@ -39,7 +39,8 @@ _subresources={
 "nodes": {
 "PATH:table_medium_broken": {
 "decomposition/precision": 9,
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/torch.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/torch.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:torch": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/torch_lit.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/torch_lit.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:torch_lit": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }

--- a/addons/kaykit_dungeon_remastered/Assets/gltf/torch_mounted.gltf.import
+++ b/addons/kaykit_dungeon_remastered/Assets/gltf/torch_mounted.gltf.import
@@ -38,7 +38,8 @@ _subresources={
 },
 "nodes": {
 "PATH:torch_mounted": {
-"generate/physics": true
+"generate/physics": true,
+"physics/shape_type": 0
 }
 }
 }


### PR DESCRIPTION
This PR specify physics/shape_type=0 for decompose-convex types to work around a Godot 4.3 import issue.